### PR TITLE
RecastLayers: set RC_MAX_LAYERS and RC_MAX_NEIS as optional defines

### DIFF
--- a/Recast/Source/RecastLayers.cpp
+++ b/Recast/Source/RecastLayers.cpp
@@ -29,8 +29,21 @@
 
 // Must be 255 or smaller (not 256) because layer IDs are stored as
 // a byte where 255 is a special value.
-static const int RC_MAX_LAYERS = 63;
-static const int RC_MAX_NEIS = 16;
+#ifndef RC_MAX_LAYERS_DEF
+#define RC_MAX_LAYERS_DEF 63
+#endif
+
+#if RC_MAX_LAYERS_DEF > 255
+#error RC_MAX_LAYERS_DEF must be 255 or smaller
+#endif
+
+#ifndef RC_MAX_NEIS_DEF
+#define RC_MAX_NEIS_DEF 16
+#endif
+
+// Keep type checking.
+static const int RC_MAX_LAYERS = RC_MAX_LAYERS_DEF;
+static const int RC_MAX_NEIS = RC_MAX_NEIS_DEF;
 
 struct rcLayerRegion
 {


### PR DESCRIPTION
It makes possible for a project integrating Recast to set custom values via CXXFLAGS while remaining build system agnostic.

Alternative for:

- https://github.com/Unvanquished/recastnavigation/pull/3

See game side:

- https://github.com/Unvanquished/Unvanquished/pull/2620
